### PR TITLE
DEVOPS-2114: Configure CI for Java SDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,6 @@ addons:
   sonarcloud:
     organization: "incountry"
 
-git:
-  depth: false
-
-before_cache:
-  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
-
-cache:
-  directories:
-    - $HOME/.gradle/caches/
-    - $HOME/.gradle/wrapper/
-    - dependencyCheck
-    - gradle-container
-
 language:
   java
 
@@ -27,27 +13,47 @@ sudo: false
 notifications:
   email: false
 
+before_cache:
+  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+    - dependencyCheck
+    - gradle-container
+
 before_install:
-  # get used Gradle version and download URL from file 'gradle-wrapper.properties'
+  # Get used Gradle version and download URL from file 'gradle-wrapper.properties'
   - while IFS='=' read -r key value; do key=$(echo $key | tr '.' '_'); eval ${key}=\${value}; done < "gradle/wrapper/gradle-wrapper.properties"; gradleUrl=$(echo ${distributionUrl} | tr -d \\)
-  # get gradle zip file name
-  - arr=(${gradleUrl//// })
-  - gradleZipFile=${arr[${#arr[*]}-1]}
-  # get gradle directory name after unzipping
-  - arr2=(${gradleZipFile//-bin/ })
-  - gradleDirectory=$arr2
-  # check used Gradle binaries exist, if not download it
-  - if [ -d "$PWD/gradle-container/$gradleDirectory" ]; then mv $PWD/gradle-container/$gradleDirectory $PWD; else wget ${gradleUrl}; unzip -qq ${gradleZipFile}; fi
-  - export GRADLE_HOME=$PWD/${gradleDirectory}
-  - export PATH=$GRADLE_HOME/bin:$PATH
-  - echo ${GRADLE_HOME}
-  - echo ${PATH}
-  - gradle -v
+  # Get gradle zip file name and gradle directory name
+  - arr=(${gradleUrl//// }); gradleZipFile=${arr[${#arr[*]}-1]}
+  - arr2=(${gradleZipFile//-bin/ }); gradleDirectory=$arr2
+  # Check if Gradle binaries exist. If not, download them
+  - if [ -d "$PWD/gradle-container/$gradleDirectory" ]; then mv $PWD/gradle-container/$gradleDirectory $PWD; else wget -q ${gradleUrl}; unzip -qq ${gradleZipFile}; fi
+  - export GRADLE_HOME=$PWD/${gradleDirectory}; export PATH=$GRADLE_HOME/bin:$PATH
 
-script:
-  - gradle build jacocoTestReport sonarqube
-  - gradle integrationTest
-  # move custom Gradle binaries to cache
-  - rm -rf $PWD/gradle-container/*
-  - mv $PWD/$gradleDirectory $PWD/gradle-container
+jobs:
+  include:
+    - stage: build
+      name: "Build the code, scan with Snyk, run tests & Sonar"
+      script:
+        # Print debug information
+        - echo "Building for branch=$TRAVIS_BRANCH, PR=${TRAVIS_PULL_REQUEST} ..."; env | grep "COMMIT\|PULL\|BRANCH"
+        # Perform the build
+        - ./travis-build.sh
+        # move custom Gradle binaries to the cache
+        - rm -rf $PWD/gradle-container/*
+        - mv $PWD/$gradleDirectory $PWD/gradle-container
+    - stage: build
+      name: "Run integration tests"
+      script:
+        - gradle integrationTest
 
+stages:
+  - name: build
+
+env:
+  global:
+    - APP_NAME=sdk-java

--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,10 @@ sonarqube {
         property "sonar.organization", "incountry"
         property "sonar.java.coveragePlugin", "jacoco"
         property "sonar.coverage.jacoco.xmlReportPaths", "${buildDir}/jacoco/test/jacocoTestReport.xml"
+        property "sonar.buildbreaker.skip", "false"
+        property "sonar.qualitygate.wait", "true"
+        property "sonar.qualitygate.timeout", "300"
+        property "sonar.verbose", "false"
     }
 }
 

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+if [[ "${TRAVIS_BUILD_SCRIPT_DEBUG_ENABLED:-false}" == 'true' ]]; then
+  set -x
+fi
+
+set -e
+set -o pipefail
+
+RED="\033[31;1m"
+GREEN="\033[32;1m"
+RESET="\033[0m"
+
+log_info() {
+  echo -e "${GREEN}$1${RESET}"
+}
+log_error() {
+  echo -e "${RED}$1${RESET}"
+}
+
+# Return true if branch matches the grep regexp pattern specified and false otherwise
+branch_matches() {
+  if grep -qE "$1" <(echo "$TRAVIS_BRANCH"); then return 0; else return 1; fi
+}
+
+# We need the PR branch, develop branch and master branch to be present in different cases to allow Sonar properly build test coverage diffs and commit annotations in coverage details
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then # Fetch the PR branch with complete history for Travis PR builds in order to let Sonar properly display annotations in coverage details
+  git fetch --no-tags https://github.com/${TRAVIS_PULL_REQUEST_SLUG}.git +refs/heads/${TRAVIS_BRANCH}:refs/remotes/origin/${TRAVIS_BRANCH}
+fi
+
+# Perform the build
+gradle build jacocoTestReport sonarqube
+
+if [[ "$TRAVIS_PULL_REQUEST" == 'false' ]] && branch_matches "^master$|^develop$|^SB_*|^RC_*"; then
+  npm install -g snyk
+  snyk monitor --org=incountry --prune-repeated-subdependencies --remote-repo-url="${APP_NAME}" --project-name="${APP_NAME}:${TRAVIS_BRANCH}"
+else
+  log_info "Snyk dependency scan skipped"
+fi


### PR DESCRIPTION
This PR implements the following:

- Execute Sonar scanner on each CI run. For every branch and for every PR
- Execute Snyk scan should be executed for commits on master; SB_* ; RC_* ; develop  branches
- Block the PR if the Sonar quality gate fails

Example links:
- Example Travis build: https://travis-ci.com/github/incountry/sdk-java/builds/182474574
- Example Sonar report for PR: https://sonarcloud.io/dashboard?id=incountry_sdk-java&pullRequest=154 
- Example Sonar report for branch: https://sonarcloud.io/dashboard?id=incountry_sdk-java&branch=FB_DEVOPS-2114
- Example SNYK report: https://app.snyk.io/org/incountry/project/8021f514-b208-422e-9157-af6a445e9f50/history/f6c268c9-ca73-49a2-924c-1e6ed1595898
- Example coverage report: https://sonarcloud.io/component_measures?branch=FB_DEVOPS-2114&id=incountry_sdk-java&metric=new_lines_to_cover&view=list